### PR TITLE
prepare prebuilding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+---
+notifications:
+  email: false
+language: cpp
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - g++-4.8-multilib
+    - gcc-multilib
+
+# Build matrix
+os:
+- linux
+- osx
+env:
+  global:
+  - secure: ""
+  matrix:
+  - TRAVIS_NODE_VERSION="6"
+  - TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - TRAVIS_NODE_VERSION="8"
+  - TRAVIS_NODE_VERSION="8" ARCH="x86"
+  - TRAVIS_NODE_VERSION="9"
+  - TRAVIS_NODE_VERSION="9" ARCH="x86"
+  - TRAVIS_NODE_VERSION="10"
+matrix:
+  exclude:
+  - os: osx
+    env: TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="8" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="9" ARCH="x86"
+
+before_install:
+
+# download node if testing x86 architecture
+- nvm install $TRAVIS_NODE_VERSION
+- >
+  if [[ "$ARCH" == "x86" ]]; then
+    BASE_URL=$(node -p "'https://nodejs.org/dist/' + process.version");
+    X86_FILE=$(node -p "'node-' + process.version + '-' + process.platform + '-x86'");
+    wget $BASE_URL/$X86_FILE.tar.gz;
+    tar -xf $X86_FILE.tar.gz;
+    nvm deactivate;
+    export PATH=`pwd`/$X86_FILE/bin:$PATH;
+  fi;
+
+# use g++-4.8 on Linux
+- if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
+- $CXX --version
+
+# Cleanup the output of npm
+- npm config set progress false
+- npm config set spin false
+
+# print versions
+- uname -a
+- which node; file `which node`
+- node --version
+- node -p 'process.platform + "@" + process.arch'
+- npm --version
+
+# figure out if we should publish
+- PUBLISH_BINARY=false
+- echo $TRAVIS_BRANCH
+- echo `git describe --tags --always HEAD`
+- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
+- echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
+
+install:
+# ensure source install works
+- npm install --build-from-source
+
+script:
+- npm run lint
+- node ./
+- npm test
+
+# if publishing, do it
+- >
+  if [[ $PUBLISH_BINARY == true ]]; then
+    echo "building and uploading binaries"
+    npm run prebuild-ci;
+  fi;
+
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,68 @@
+os: unstable
+environment:
+  PREBUILD_TOKEN:
+    secure:
+
+  matrix:
+  - nodejs_version: "6"
+  - nodejs_version: "8"
+  - nodejs_version: "9"
+  - nodejs_version: "10"
+
+platform:
+- x86
+- x64
+
+install:
+- ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform;
+- ps: >
+    npm config set progress false
+    npm config set spin false
+
+- ps: >
+    @{
+      "nodejs_version" = $env:nodejs_version
+      "platform" = $env:platform
+      "node binary version" = $(node -v)
+      "node platform@arch" = $(node -p 'process.platform + process.arch')
+      "npm version" = $(npm -v)
+      "APPVEYOR_REPO_COMMIT_MESSAGE" = $env:APPVEYOR_REPO_COMMIT_MESSAGE
+      "git latest tag" = "$(git describe --tags --always HEAD)"
+      "appveyor_repo_tag" = $env:appveyor_repo_tag
+    } | Out-String | Write-Host;
+
+# Check if we're building the latest tag, if so
+# then we publish the binaries if tests pass.
+- ps: >
+    if ($env:appveyor_repo_tag -match "true" -and ("$(git describe --tags --always HEAD)" -eq $env:appveyor_repo_tag_name)) {
+      $env:publish_binary = "true";
+    }
+    if ($env:publish_binary -eq "true") {
+      "We're publishing a binary!" | Write-Host
+    } else {
+      "We're not publishing a binary" | Write-Host
+    }
+    true;
+
+# We don't currently have a port to test on windows
+# - ps: $env:TEST_PORT = "COM1";
+
+build_script:
+- npm install --build-from-source
+
+test_script:
+- ps: >
+    npm run lint
+    node ./
+
+# If we run npm test in powershell it'll have the wrong encoding so we have to do it like this
+- npm test
+
+- ps: >
+    if ($env:publish_binary -eq "true") {
+      "building and uploading binaries" | Write-Host;
+      npm run prebuild-ci;
+    }
+    true;
+
+deploy: OFF

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "An Ed25519 implementation for node.js (used for HAP)",
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.10.0"
+    "nan": "^2.10.0",
+    "prebuild-install": "^4.0.0"
   },
   "main": "index.js",
   "scripts": {
-    "install": "node-gyp rebuild",
-    "test": "mocha"
+    "test": "mocha",
+    "install": "prebuild-install || node-gyp rebuild",
+    "rebuild": "prebuild --compile",
+    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild-ci": "prebuild-ci"
   },
   "keywords": [
     "Ed25519",
@@ -24,5 +28,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/KhaosT/ed25519.git"
+  },
+  "devDependencies": {
+    "prebuild": "^7.6.0",
+    "prebuild-ci": "^2.2.3"
   }
 }


### PR DESCRIPTION
Not meant to merge right away. I'd just like to suggest to add prebuilds for all HAP-Nodejs dependencies. This PR is just meant as a first example, mostly copied from node-serialport. What I'd like to do is not only prebuilding for Mac and Linux amd64/x86 but also for Linux Arm (should be possible with Qemu on Travis). Motivation is that I'd like to use hap-nodejs on a Buildroot based Linux that lacks build tools...
What do you think about that? If you're ok with it I would start to create a Travis/Qemu job and test it.
